### PR TITLE
Partially fix module detection.

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -1,2 +1,6 @@
 MODDIR="${0%/*}"
-mount -t overlay -o lowerdir=/system/etc,upperdir=$MODDIR/system/etc,workdir=$MODDIR/worker KSU /system/etc
+if [ "$(pwd)" -ne "$MODDIR" ]; then
+    cd "$MODDIR"
+fi
+
+mount -t overlay -o lowerdir=/system/etc,upperdir=system/etc,workdir=worker KSU /system/etc


### PR DESCRIPTION
Apps can detect modules by looking for "/adb" in /proc/self/mountinfo, so doing the mount with a relative path should prevent this. Obviously, they can still target specifically this module, by looking for "/system/etc" instead, but that's unlikely.

This should fix #11.