### PR TITLE
scripts/customize: abort installation on magic mount for non-sdcardfs users

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+PATH=/data/adb/ap/bin:/data/adb/ksu/bin:/data/adb/magisk:$PATH
 
 # prevent installation on magic mount managers
 # this will not work since on magic mount, /data/adb/modules is not ext4
@@ -12,8 +13,9 @@ if ! grep -q sdcardfs /proc/filesystems >/dev/null 2>&1; then
 fi
 
 mkdir -p "$MODPATH/system/etc"
-cp -af /system/etc/hosts "$MODPATH/system/etc/hosts"
-chcon -r u:object_r:system_file:s0 "$MODPATH/system"
+busybox chcon --reference"/system" "$MODPATH/system"
+cat /system/etc/hosts > "$MODPATH/system/etc/hosts"
+busybox chcon --reference"/system/etc/hosts" "$MODPATH/system/etc/hosts"
 chmod 644 "$MODPATH/system/etc/hosts"
 mkdir "$MODPATH/worker"
 touch "$MODPATH/skip_mount"

--- a/customize.sh
+++ b/customize.sh
@@ -1,6 +1,21 @@
+#!/bin/sh
+
+# prevent installation on magic mount managers
+# this will not work since on magic mount, /data/adb/modules is not ext4
+# and cannot be used as an overlay source due to native casefolding (ovl_dentry_weird)
+# if user is on sdcardfs, it can work. here we perform this check.
+if ! grep -q sdcardfs /proc/filesystems >/dev/null 2>&1; then
+	# test for magic mount
+	if [ "$KSU_MAGIC_MOUNT" = "true" ] || [ "$APATCH_BIND_MOUNT" = "true" ] || { [ -f /data/adb/magisk/magisk ] && [ -z "$KSU" ] && [ -z "$APATCH" ]; }; then
+		abort '[!] This module is not compatible to magic mount managers!'
+	fi
+fi
+
 mkdir -p "$MODPATH/system/etc"
 cp -af /system/etc/hosts "$MODPATH/system/etc/hosts"
 chcon -r u:object_r:system_file:s0 "$MODPATH/system"
 chmod 644 "$MODPATH/system/etc/hosts"
 mkdir "$MODPATH/worker"
 touch "$MODPATH/skip_mount"
+
+# EOF


### PR DESCRIPTION
scripts/customize: abort installation on magic mount for non-sdcardfs users

env var references:
context: https://github.com/5ec1cff/KernelSU/pull/5 
merged in: https://github.com/5ec1cff/KernelSU/commit/38eb94b1dd58e66c80f1dc251f81388ab81c2c51

context: https://github.com/bmax121/APatch/issues/763#issuecomment-2517263387
merged in: https://github.com/bmax121/APatch/commit/d1200d0fdacf655b64de703e2163867761c2b32a